### PR TITLE
fix: guard nil NSApp.currentEvent in statusBarButtonClicked (fixes #4)

### DIFF
--- a/ClipVault/AppDelegate.swift
+++ b/ClipVault/AppDelegate.swift
@@ -98,9 +98,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // MARK: - Menu Bar Actions
 
     @objc private func statusBarButtonClicked() {
-        let event = NSApp.currentEvent!
+        // NSApp.currentEvent is nil when triggered via the Accessibility API
+        // (System Events, BetterTouchTool, Raycast, Shortcuts.app, etc.), so a
+        // force-unwrap here crashes the app on synthetic clicks. Default to the
+        // main menu when no event is present.
+        let event = NSApp.currentEvent
 
-        if event.type == .rightMouseUp {
+        if event?.type == .rightMouseUp {
             // Right click - show context menu with settings/quit
             showContextMenu()
         } else {


### PR DESCRIPTION
## Summary

Fixes #4. `statusBarButtonClicked()` force-unwrapped `NSApp.currentEvent`, which is `nil` for status-bar clicks dispatched through the Accessibility API (System Events, BetterTouchTool, Raycast, Shortcuts.app, AppleScript, etc.). Any user attempt to wire up a global hotkey to open ClipVault crashes the app.

This guards the unwrap and defaults to the main history menu (the left-click behaviour) when no `NSEvent` is present, which is the safer choice — a synthetic click is overwhelmingly likely to want the history menu rather than the quit/settings context menu.

## Diff

```swift
@objc private func statusBarButtonClicked() {
    let event = NSApp.currentEvent
    if event?.type == .rightMouseUp {
        showContextMenu()
    } else {
        showMenu()
    }
}
```

## Test plan

- [x] Normal left click on the menu bar icon → main history menu opens (unchanged)
- [x] Normal right click on the menu bar icon → context menu opens (unchanged)
- [x] `osascript -e 'tell application "System Events" to tell process "ClipVault" to click menu bar item 1 of menu bar 2'` → main menu opens; app no longer crashes
- [x] BetterTouchTool hotkey wired to the same AppleScript → main menu opens; app no longer crashes